### PR TITLE
Accept const char * rather than char * in Profiler::{start,end}SubProfile

### DIFF
--- a/include/gameLayer/profiler.h
+++ b/include/gameLayer/profiler.h
@@ -62,8 +62,8 @@ struct Profiler
 
 	void endFrame();
 
-	void startSubProfile(char *c);
-	void endSubProfile(char *c);
+	void startSubProfile(const char *c);
+	void endSubProfile(const char *c);
 
 	void setSubProfileManually(char *c, PL::ProfileRezults rezults);
 

--- a/src/gameLayer/profiler.cpp
+++ b/src/gameLayer/profiler.cpp
@@ -194,7 +194,7 @@ void Profiler::endFrame()
 }
 
 //
-void Profiler::startSubProfile(char *c)
+void Profiler::startSubProfile(const char *c)
 {
 	if (REMOVE_IMGUI) { return; }
 
@@ -209,7 +209,7 @@ void Profiler::startSubProfile(char *c)
 	}
 }
 
-void Profiler::endSubProfile(char *c)
+void Profiler::endSubProfile(const char *c)
 {
 	if (REMOVE_IMGUI) { return; }
 


### PR DESCRIPTION
This fixes compile warning: `ISO C++ forbids converting a string constant to ‘char*’` in various places