### PR TITLE
Do not redefine default argument value in assertFunc* definitions

### DIFF
--- a/src/platform/platformTools.cpp
+++ b/src/platform/platformTools.cpp
@@ -123,7 +123,7 @@ void assertFuncProduction(
 	const char *expression,
 	const char *file_name,
 	unsigned const line_number,
-	const char *comment = "---")
+	const char *comment)
 {
 
 	raise(SIGABRT);
@@ -134,7 +134,7 @@ void assertFuncInternal(
 	const char *expression,
 	const char *file_name,
 	unsigned const line_number,
-	const char *comment = "---")
+	const char *comment)
 {
 
 	raise(SIGABRT);


### PR DESCRIPTION
Redefining default argument values is against the C++ standard.