### PR TITLE
Fixed bad cast syntax in items.cpp

### DIFF
--- a/src/gameLayer/gameplay/items.cpp
+++ b/src/gameLayer/gameplay/items.cpp
@@ -47,7 +47,7 @@ void Item::formatIntoData(std::vector<unsigned char> &data)
 {
 	if (type == 0 || counter == 0)
 	{
-		writeData(data, unsigned short(0));
+		writeData(data, (unsigned short)(0));
 	}
 	else
 	{


### PR DESCRIPTION
Whatever compiler led this slip surely isn't standard compliant.